### PR TITLE
Don’t do anything if there is no selection region

### DIFF
--- a/show_unicode_name.py
+++ b/show_unicode_name.py
@@ -10,5 +10,13 @@ class NedShowUnicode(sublime_plugin.EventListener):
         self.show_unicode(view)
 
     def show_unicode(self, view):
-        selected = view.substr(view.sel()[0].a)
-        view.set_status('a-ned-unicode', "U+{0:0>4X} #{0} {1}".format(ord(selected), unicodedata.name(selected, selected.encode('unicode_escape').decode('utf-8')).title()))
+        regions = view.sel()
+        if len(regions) > 0:
+            selected = view.substr(regions[0].a)
+            view.set_status(
+                'a-ned-unicode',
+                "U+{0:0>4X} #{0} {1}".format(
+                    ord(selected),
+                    unicodedata.name(selected, selected.encode('unicode_escape').decode('utf-8')).title()
+                )
+            )


### PR DESCRIPTION
On some occasions (on startup and on executing some commands such as `lsp_document_symbols` which in turn executes `lsp_selection_clear`), the `show_unicode` function might be executed with an empty selection set (i.e. not even one empty region). The function currently tries to call `view.sel()[0]`, which generates an IndexError in that case.